### PR TITLE
Fix #20: resolve undefined variable 'rawcts' in flush_out_empty_samples

### DIFF
--- a/R/filter_experiment.R
+++ b/R/filter_experiment.R
@@ -79,10 +79,10 @@ filter_experiment <- function(SEobj = NULL, samplesToKeep = NULL, featuresToKeep
 
     #Flush out empty Samples
     if (flush_out_empty_samples){
-        emptysamples <- names(which(colSums(rawcts) == 0) == TRUE)
+        emptysamples <- names(which(colSums(assays(SEobj)$BaseCounts) == 0) == TRUE)
         if (length(emptysamples) > 0){
             flog.info(paste("Samples", paste0(emptysamples, collapse = ", "), "are empty and will be discarded."))
-            validsamples <- names(which(colSums(rawcts) > 0) == TRUE)
+            validsamples <- names(which(colSums(assays(SEobj)$BaseCounts) > 0) == TRUE)
             SEobj <- SEobj[ , validsamples]
         }
     }


### PR DESCRIPTION
## Summary

Fixed a latent bug in `filter_experiment()` where the `flush_out_empty_samples` block referenced an undefined variable `rawcts`, causing an immediate error whenever `flush_out_empty_samples = TRUE` was passed. Fixes #20 

## Problem

In `filter_experiment.R` the `flush_out_empty_samples` block (lines 81-88) called `colSums(rawcts)` to identify samples with zero total counts. However, `rawcts` was never defined anywhere in the function, or in the wider codebase. Attempting to set flush_out_empty_samples to TRUE causes an error:

```
filter_experiment(SEobj = expvec_MR50[["Contig_LKT"]], flush_out_empty_samples = TRUE)

Error in filter_experiment(SEobj = expvec_MR50[["Contig_LKT"]], flush_out_empty_samples = TRUE) : 
  object 'rawcts' not found
```

I believe `rawcts` is a remnant of an earlier variable naming convention that was not updated.

Because `flush_out_empty_samples` defaults to `FALSE`, this bug was latent.

## Fix

Replaced both occurrences of `rawcts` with `assays(SEobj)$BaseCounts` directly. This is the correct data source, and is appropriate here because `countmat_raw` is extracted from `SEobj` *after* this block. This means it will automatically reflect any samples removed by the empty-sample flush step.

## Testing

Ran multiple tests to ensure this fix works as expected. Tested against a real dataset (`expvec_MR50[["Contig_LKT"]]`, 59 samples):

1. Tested against the existing dataset:

Command:
```
> data(expvec_MR50)
> result <- filter_experiment(SEobj = expvec_MR50[["Contig_LKT"]], flush_out_empty_samples = TRUE)
> ncol(result)
```

Output:

```
[1] 59
> result
class: SummarizedExperiment 
dim: 10013 59 
metadata(5): TotalBasesSequenced TotalBasesSequencedinAnalysis analysis
  version ctable
assays(3): BaseCounts GenomeCompleteness GenomeContamination
rownames(10013): LKT__s__2768039_uncultured_Duncaniella_Unclassified
  LKT__s__1622_Ligilactobacillus_murinus ... LKT__g__95729_Stemphylium
  LKT__f__1799696_Sporidiobolaceae
rowData names(12): Gram Taxid ... Species LKT
colnames(59): MR50G1M1D1dna202212 MR50G1M2D1dna202212 ...
  MR50G3M4CECdna202212 MR50G3M5CECdna202212
colData names(15): Sample Well ... GbNAHS PctAss
```

2. Tested against a zeroed out sample column

Command:
```
> test_SEobj <- expvec_MR50[["Contig_LKT"]]   
> assays(test_SEobj)$BaseCounts[, 1] <- 0 
> result <- filter_experiment(SEobj = test_SEobj, flush_out_empty_samples = TRUE)
INFO [2026-03-05 15:46:28] Samples MR50G1M1D1dna202212 are empty and will be discarded.
> ncol(result)
```

Output:
```
[1] 58
> result
class: SummarizedExperiment 
dim: 10013 58 
metadata(5): TotalBasesSequenced TotalBasesSequencedinAnalysis analysis
  version ctable
assays(3): BaseCounts GenomeCompleteness GenomeContamination
rownames(10013): LKT__s__2768039_uncultured_Duncaniella_Unclassified
  LKT__s__1622_Ligilactobacillus_murinus ... LKT__g__95729_Stemphylium
  LKT__f__1799696_Sporidiobolaceae
rowData names(12): Gram Taxid ... Species LKT
colnames(58): MR50G1M2D1dna202212 MR50G1M3D1dna202212 ...
  MR50G3M4CECdna202212 MR50G3M5CECdna202212
colData names(15): Sample Well ... GbNAHS PctAss
```

3. Tested against multiple zeroed out sample columns

Command:
```
> test_SEobj <- expvec_MR50[["Contig_LKT"]]   
> assays(test_SEobj)$BaseCounts[, 1] <- 0  
> assays(test_SEobj)$BaseCounts[, 5] <- 0
> result <- filter_experiment(SEobj = test_SEobj, flush_out_empty_samples = TRUE)
INFO [2026-03-05 16:14:38] Samples MR50G1M1D1dna202212, MR50G1M5D1dna202212 are empty and will be discarded.
> ncol(result)
```

Output:
```
[1] 57
> result
class: SummarizedExperiment 
dim: 10013 57 
metadata(5): TotalBasesSequenced TotalBasesSequencedinAnalysis analysis
  version ctable
assays(3): BaseCounts GenomeCompleteness GenomeContamination
rownames(10013): LKT__s__2768039_uncultured_Duncaniella_Unclassified
  LKT__s__1622_Ligilactobacillus_murinus ... LKT__g__95729_Stemphylium
  LKT__f__1799696_Sporidiobolaceae
rowData names(12): Gram Taxid ... Species LKT
colnames(57): MR50G1M2D1dna202212 MR50G1M3D1dna202212 ...
  MR50G3M4CECdna202212 MR50G3M5CECdna202212
colData names(15): Sample Well ... GbNAHS PctAss
```

4. Testing against multiple zeroed out sample columns with `flush_out_empty_samples = FALSE`

Command:

```
> test_SEobj <- expvec_MR50[["Contig_LKT"]]                                         
>   assays(test_SEobj)$BaseCounts[, 1] <- 0                                           
>   assays(test_SEobj)$BaseCounts[, 5] <- 0
> result <- filter_experiment(SEobj = test_SEobj, flush_out_empty_samples = FALSE)
> ncol(result)
```

Output:

```
[1] 59
> result
class: SummarizedExperiment 
dim: 10013 59 
metadata(5): TotalBasesSequenced TotalBasesSequencedinAnalysis analysis
  version ctable
assays(3): BaseCounts GenomeCompleteness GenomeContamination
rownames(10013): LKT__s__2768039_uncultured_Duncaniella_Unclassified
  LKT__s__1622_Ligilactobacillus_murinus ... LKT__g__95729_Stemphylium
  LKT__f__1799696_Sporidiobolaceae
rowData names(12): Gram Taxid ... Species LKT
colnames(59): MR50G1M1D1dna202212 MR50G1M2D1dna202212 ...
  MR50G3M4CECdna202212 MR50G3M5CECdna202212
colData names(15): Sample Well ... GbNAHS PctAss
```